### PR TITLE
feat: sync agent skills to .agents directory with CI check

### DIFF
--- a/.agents/skills/app-preview/SKILL.md
+++ b/.agents/skills/app-preview/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: app-preview
+description: Generate a gallery app's 720x160 preview.png or preview.gif by recording its draw stream and replaying it deterministically, saved into the app's folder. Takes the app slug plus optional --seconds, --loop, --png and any arguments the app itself needs. No emulator checkout, browser or Playwright required.
+disable-model-invocation: true
+---
+
+# Capture an app preview
+
+Produces the `preview.gif` / `preview.png` that `CONTRIBUTING.md` requires:
+720x160, real render output, in the app's folder.
+
+Arguments: `<app-slug> [--seconds N] [--loop] [--png] [-- <app args>]`
+
+This used to drive Playwright against a running emulator and sample its canvas
+on a timer. It no longer does: `tools/busyrec.py` records the app's draw stream
+and `tools/render/render.mjs` replays it through the emulator's renderer
+(vendored under `tools/render/vendor/`). One command, no emulator, no browser,
+and the timing comes out exact instead of jittery.
+
+## Steps
+
+1. **Generate it.** From the repo root:
+
+   ```bash
+   npm run preview -- <app-slug> --seconds 6
+   ```
+
+   Add `--loop` for anything animated: it trims to a seamless loop point and
+   usually cuts the file size substantially. Add `--png` for a still. Pass app
+   arguments after `--`, e.g. `npm run preview -- text-display -- --text "HI"`.
+
+   Check the app's own flags before recording. If it takes an fps flag, try a
+   few values rather than jumping to its maximum: an app that uploads a PNG per
+   frame makes two HTTP calls per frame and usually cannot sustain its own top
+   setting. Ask for more than it can deliver and the recorder samples an uneven
+   stream onto an even grid, which shows up as two delay values in the finished
+   GIF and reads as judder. The best setting is the highest one where the
+   busyrec `rate` still lands close to what you asked for. `lunar-phases`
+   measured: `--fps 12` gives 11.2 draws/s and one delay, `--fps 16` gives 13.8
+   and one delay, `--fps 20` gives 16.5 and alternating 50/100 ms. Apps that
+   replay on a timer usually have a demo flag (`--demo`, `--auto-roll N`) worth
+   passing so a full cycle lands inside the recording window.
+
+   The command records first (you will see the busyrec report, which is worth
+   reading) and then renders. It writes straight to `apps/<slug>/preview.gif`
+   unless you pass `--out`.
+
+2. **Look at it.** Read the generated file. Check the app is actually visible,
+   is not clipped at the edges of the 72x16 grid, and that the window caught the
+   interesting part of the app rather than a loading state. `--start <seconds>`
+   skips further into the recording.
+
+   For a GIF, verify the motion instead of trusting the frame count. Counting
+   how many frames merely *differ* proves nothing: many apps twinkle pixels
+   every frame, so that check passes even on a badly juddering preview. Track
+   the position of the moving element across frames and look at the per-frame
+   deltas. They should change smoothly and never reverse direction.
+
+3. **Check it passes.** `npm run check -- <app-slug>` must report no errors:
+   that is what validates the 720x160 dimensions and the file size budget.
+
+4. **Report** the path, dimensions, frame count and size, plus anything the
+   busyrec report flagged about the app itself.
+
+## Notes
+
+- **An app that draws nothing is usually not broken.** Alert-style apps
+  (`iss-alert`, `pollen-alarm`, `buienradar-alarm`) only draw when they have
+  something to report. The tool retries once with `--test` automatically; if an
+  app has no `--test` flag, it genuinely has nothing to preview right now.
+- **BUSY-mode apps cannot be previewed this way.** An app that drives
+  `PUT /api/busy/snapshot` (like `busy-defaults`) relies on the firmware's theme
+  animations, which the emulator stores but never renders. Those previews still
+  have to come off real hardware. `busycheck` flags such apps so this is not a
+  surprise.
+- **Judder in the preview is the app's own.** The renderer replays the recorded
+  draw stream at its real timestamps, so the capture cannot add lag any more. If
+  motion still steps unevenly, the app is moving a sprite by whole pixels across
+  a 72-px display, so fast motion jumps 2 to 4 LEDs per frame. Diagnose it by
+  computing the intended per-frame positions from the app's own easing, and
+  report it as a review finding rather than editing the app to make the preview
+  look better.
+- **Apps that need button or wheel input** (`/api/status/ws`) are not covered by
+  the built-in stub. Start the emulator and record through it:
+  `npm run preview -- <slug> --upstream 127.0.0.1:8080`.
+- Apps needing credentials read them from the environment; pass them through
+  with `busyrec --env KEY=VALUE` and `--from` the resulting recording.
+- Stock icons and stock animations render only when a `busybar-emulator`
+  checkout sits next to this repo; the tool says so when it needs one.

--- a/.agents/skills/app-review/SKILL.md
+++ b/.agents/skills/app-review/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: app-review
+description: Review a community app submission end to end. Checks out the pull request, validates it against CONTRIBUTING.md, runs the app and watches every call it makes to the bar, regenerates the preview to compare against the submitted one, and writes a review summary plus a draft PR comment. Takes a PR number, or an app slug to review what is already checked out.
+disable-model-invocation: true
+---
+
+# Review an app submission
+
+Turns a submission into a written review in one pass. Arguments:
+`<pr-number | app-slug> [-- <app args>]`.
+
+This exists because the only CI gate is `npm run build`, which validates the
+manifest schema and nothing else. Everything that actually breaks a submission
+gets found by running it, and the same handful of problems keep recurring:
+accumulating element ids, colours missing the alpha byte, an `APP` constant that
+does not match the folder, a preview at the wrong size, an app that treats a 409
+as fatal.
+
+## The one thing to get right
+
+**Never merge on a green check alone, and never trust the preview you were
+sent.** A preview is just a file; it can be from a different version of the app,
+from another device, or hand-made. Regenerating it (step 4) is what verifies
+that the code in the PR actually produces what the gallery will show.
+
+## Steps
+
+1. **Get the branch into a worktree.** A submission is almost always based on a
+   commit older than these tools, so checking it out in place would take
+   `tools/` away with it. Use a worktree and keep running the tools from `main`:
+
+   ```bash
+   gh pr view <n> --json title,author,body,files,additions,deletions
+   git fetch origin pull/<n>/head:pr<n>-review -f
+   git worktree add /tmp/pr<n> pr<n>-review
+   ```
+
+   Both `busycheck.py` and `render.mjs` accept an absolute app folder, so every
+   command below points at `/tmp/pr<n>/apps/<slug>/` while running from this
+   checkout. Note which app folder the PR touches; a PR should add exactly one.
+   Read the PR body for anything the author says about credentials or arguments.
+
+2. **Read the code.** Open `/tmp/pr<n>/apps/<slug>/app.py` in full before running it. You
+   are about to execute a stranger's code: check what it does with the network
+   and the filesystem, and that any dependency in `requirements.txt` is
+   justified in the PR (only `busylib` and `requests` are pre-approved).
+
+3. **Validate and run.**
+
+   ```bash
+   python3 tools/busycheck.py /tmp/pr<n>/apps/<slug> --run --verbose
+   ```
+
+   This does the static pass (slug, manifest, preview dimensions, element ids,
+   colours, `--host` default) and then records the app and reports its
+   behaviour. If it needs arguments or credentials, the report says so; re-run
+   with `-- --flag value`, or `busyrec --env KEY=VALUE`.
+
+   Then check it survives losing the screen:
+
+   ```bash
+   python3 tools/busyrec.py /tmp/pr<n>/apps/<slug> --seconds 8 --steal-at 3
+   ```
+
+   A higher-priority app takes over at t=3. The app must keep running and keep
+   trying, not crash or give up. 409 is normal on a real bar.
+
+4. **Regenerate the preview and compare.**
+
+   ```bash
+   node tools/render/render.mjs /tmp/pr<n>/apps/<slug> --seconds 6 --loop \
+     --out /tmp/review-<slug>.gif
+   ```
+
+   Read both `/tmp/review-<slug>.gif` and the submitted preview and say whether
+   they show the same app. Different data or a different moment is fine. Two
+   things are not: a preview showing something the code cannot produce, and a
+   preview with no LED grid in it. The second means it was upscaled from the raw
+   72x16 framebuffer with smoothing rather than captured as LEDs, which is what
+   `CONTRIBUTING.md` means by real emulator output. It is easy to spot side by
+   side: the device font is a 1-bpp bitmap, so genuine output has hard square
+   pixels and no grey edges.
+
+5. **Check it against real hardware if it is plugged in.** Optional but worth it
+   for anything doing layout work, since the stub cannot catch everything:
+
+   ```bash
+   python3 tools/busyrec.py /tmp/pr<n>/apps/<slug> --seconds 6 --upstream 10.0.4.20
+   ```
+
+6. **Write the review.** Group findings as blocking / worth fixing / nice to
+   have, and quote `file:line` for each. Draft a PR comment in Max's voice:
+   short, direct, warm, concrete, and English regardless of the PR's language.
+   Lead with what is good about the app. Do not post it; show it and let Max
+   decide.
+
+7. **Clean up.** Remove the worktree and its branch, plus anything the run
+   left behind:
+
+   ```bash
+   git worktree remove /tmp/pr<n> --force
+   git branch -D pr<n>-review
+   ```
+
+## What to look for beyond the automated checks
+
+The tools cover the mechanical rules. These need judgement:
+
+- **Polling interval.** Anything hitting a third-party API needs a default that
+  is safe on that API's unauthenticated rate limit. 60 s against GitHub is
+  borderline; 300 s is not.
+- **Failure handling.** A 404 or 401 from an upstream API should fail loudly and
+  stop, not retry forever in silence. Check what happens with a wrong argument.
+- **Blocking the display.** `priority` should be modest (30 is the convention
+  for ambient apps). A 100 belongs only to something genuinely urgent.
+- **Readability at 72x16.** Text at `tiny` is legible; three columns of it is
+  not. This is what the regenerated preview is for.
+- **Secrets.** Read from the environment, never a literal in `app.py`, and
+  documented in the docstring.
+
+## What the stub cannot see
+
+`busyrec` deliberately reproduces the firmware behaviours that break submissions:
+draw validation, the accumulating 100-element cap (`MAX_ELEMENTS`, and the count
+is checked before the priority check, exactly as on the bar) and priority
+arbitration including the refusal to step down without releasing. Four things it
+does not reproduce, each of which has shipped a broken app:
+
+- **Element ids are type-locked on the device.** An id once drawn as a
+  `rectangle` and later re-sent as a `text` returns `400 Bad request` on firmware
+  1.1.1. `validate_draw_body` never looks at `type` and `merge_elements` replaces
+  by id, so busyrec and the emulator both accept it silently. It bites the "park
+  it off-screen at `x=-400`" idiom: a parked rectangle has to stay a rectangle
+  (1x1, `fill_colors: ["#00000000"]`), not become a blank text element. Found on
+  `github-actions`, where every draw failed once the progress bar was hidden.
+- **Draw latency scales with element count, and the preview hides it.** The bar
+  spends about 3.6 ms per element (1 element ~5.6 ms, 48 ~169 ms, 96 ~356 ms),
+  so a full-screen rect animation runs at 3 to 6 fps there. busyrec answers in
+  well under a millisecond and the renderer replays the app's own recorded
+  timing, so the same app looks perfectly smooth in the regenerated preview.
+  Count elements per frame rather than trusting it. Anything animating with more
+  than ~30 belongs on the image path: upload a 72x16 PNG to
+  `/api/assets/upload`, draw one `image` element, flat ~50 ms/frame (~19 fps)
+  regardless of complexity. `pixel-fire`, `audio-visualizer` and `nyan-cat` were
+  all rewritten that way after crashing or crawling on hardware.
+- **Rapid re-upload of one asset filename returns `508`** (the asset is locked
+  while a draw reads it). Image-push apps must rotate a ring of ~4 filenames.
+  busyrec stores every upload without locking, so a single-filename app records
+  flawlessly and stalls on the bar.
+- **Native text sits lower on the device than in the renderer**: about 1px for
+  `bold`, 2px for `small`. Image and sprite elements land identically. So any app
+  that aligns text against a sprite, or stacks rows inside the 16px height, can
+  look right in the preview and be clipped or overlapping on hardware. Step 5, or
+  a human looking at a bar, is the only real check. `flightradar` and
+  `moneybird-invoice-paid` both had to be tuned on the device.
+
+## Pitfalls
+
+- **A blank recording usually means arguments, not a broken app.** Alert apps
+  only draw when they have something to report; the report tells you when
+  `--test` is the answer.
+- **BUSY-mode apps cannot be previewed locally at all.** If the app drives
+  `PUT /api/busy/snapshot`, the emulator stores it and renders nothing, so the
+  preview has to come from hardware. Do not ask the contributor to regenerate a
+  preview that cannot be generated.
+- **Element ids that grow per frame are the single most common real bug** and
+  it is invisible in a short run. The recorder reports the stored set growing;
+  trust that over "it worked when I tried it".
+- **Kill the app if you interrupt a run**, and clear the screen afterwards
+  (`curl -X DELETE http://127.0.0.1:8080/api/display/draw`) if you used
+  `--upstream` against the emulator or a bar.

--- a/.agents/skills/new-app/SKILL.md
+++ b/.agents/skills/new-app/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: new-app
+description: Scaffold a new gallery app folder (apps/<slug>/ with app.py + manifest.yaml) following CONTRIBUTING.md, a self-contained, stdlib-only app that drives the BUSY Bar over its HTTP API. Takes the app slug as its argument.
+disable-model-invocation: true
+---
+
+# Scaffold a new gallery app
+
+Creates `apps/<slug>/` with a minimal, runnable `app.py` and a `manifest.yaml`,
+matching this gallery's conventions in `CONTRIBUTING.md` (self-contained,
+stdlib-only, `--host` aware, `#RRGGBBAA` colors, app id = slug). Add the
+720×160 `preview.png` / `preview.gif` afterwards with the `app-preview` skill.
+
+The slug is the skill argument: `$ARGUMENTS`.
+
+## Step 1: validate the slug
+
+- Take the slug from `$ARGUMENTS`; if none was given, ask for one.
+- It must be **kebab-case**: lowercase letters, digits, and hyphens only. The
+  folder name is the app's identifier and its `application_name`.
+- Refuse if `apps/<slug>/` already exists.
+
+## Step 2: create `apps/<slug>/app.py`
+
+Use exactly this skeleton (a zero-install, stdlib-only app). Replace `<slug>`
+with the slug, fill the docstring `<Name>` / `<one-line description>` (its first
+line becomes the gallery description, keep it to one sentence), and replace the
+`HELLO` placeholder with the app's first frame.
+
+```python
+#!/usr/bin/env python3
+"""<Name>: <one-line description>.
+
+    python app.py                        # BUSY Bar over USB (always 10.0.4.20)
+    python app.py --host 127.0.0.1:8080  # emulator or a Wi-Fi bar
+"""
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+APP = "<slug>"
+
+# --- BUSY Bar HTTP API (stdlib only; docs: http://10.0.4.20/docs) ----------
+
+def _host(default="10.0.4.20"):
+    if "--host" in sys.argv:
+        i = sys.argv.index("--host")
+        if i + 1 < len(sys.argv):
+            return sys.argv[i + 1]
+    return default
+
+BASE = "http://" + _host().replace("http://", "").rstrip("/")
+
+def draw(elements, **extra):
+    body = {"application_name": APP, "elements": elements, **extra}
+    req = urllib.request.Request(BASE + "/api/display/draw",
+                                 data=json.dumps(body).encode(), method="POST",
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=5):
+        pass
+
+def text(txt, x=0, y=0, font="normal", color="#FFFFFFFF", **kw):
+    # Every element needs an id, and colors are #RRGGBBAA (API 25.0.0+).
+    return {"id": "0", "type": "text", "text": str(txt), "x": x, "y": y, "font": font, "color": color, **kw}
+
+# --- app -------------------------------------------------------------------
+
+def tick():
+    try:
+        draw([text("HELLO", x=36, y=8, font="large", align="center")])
+    except urllib.error.HTTPError as e:
+        if e.code != 409:  # 409 = a higher-priority app owns the display
+            raise
+
+if __name__ == "__main__":
+    print(f"<slug> → {BASE}  (Ctrl-C to stop)")
+    try:
+        while True:
+            tick()
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        print("\nstopped.")
+```
+
+Conventions this encodes (keep them):
+
+- **Self-contained, stdlib only.** One file, no shared helpers outside the app
+  folder. That earns the gallery's zero-install badge. If you need a library,
+  add a `requirements.txt` (only `busylib` and `requests` are pre-approved) and
+  keep the same `--host` convention.
+- **`--host` aware, USB default `10.0.4.20`.** The same file runs unchanged
+  against a USB bar, a Wi-Fi bar, or the emulator (`--host 127.0.0.1:8080`).
+- **`APP` = the folder slug**, passed as `application_name` on every draw; it
+  scopes clearing and asset uploads and must be unique in the gallery.
+- **Raw-dict elements with an `id` and `#RRGGBBAA` colors.** Fonts are the
+  device set: `tiny small normal condensed bold large extra_large`. Center on
+  the 72×16 matrix with `x=36, y=8, align="center"` (align anchors the element
+  box, so no text measuring is needed). Give each element a unique `id` when a
+  frame has more than one.
+- **Tolerate 409.** A higher-priority app may own the screen; keep ticking and
+  retry rather than crashing. A one-shot app can call `tick()` once instead of
+  looping.
+- **Reuse element ids across frames.** The firmware keeps a persistent, id-keyed
+  set per app and never releases what you stop sending, capped at 100. An app
+  that mints a fresh id every frame dies with `400 Elements number limit
+  exceeded` after about a hundred frames, even though each draw looks tiny.
+- **Add `--test`** (draw one frame, then exit) to anything that only draws
+  conditionally, like an alert. Eleven gallery apps already do. Without it the
+  app cannot be smoke-tested or previewed on a quiet day.
+- **Clear on exit.** `DELETE /api/display/draw?application_name=<APP>` inside
+  the `KeyboardInterrupt` handler, so the app does not leave its last frame
+  stuck on the bar.
+
+## Step 3: create `apps/<slug>/manifest.yaml`
+
+```yaml
+name: <Title Case Name>
+author: <github_username>
+description: <one-line description, max 200 chars>
+tags:
+  - <tag>
+preview: ./preview.png
+```
+
+Field rules (from `CONTRIBUTING.md`): `name` 1–50 chars, title case; `author`
+the GitHub username; `description` 1–200 chars, plain text; `tags` 1–5 lowercase
+(common: `clock weather info effect animation game monitor`); `preview` points
+at the file added in step 4 (use `./preview.gif` for a GIF). Add `repo: <url>`
+only if the app also lives in its own repository.
+
+## Step 4: add a preview and test
+
+```bash
+npm run preview -- <slug>        # records the app and writes apps/<slug>/preview.gif
+npm run check -- <slug> --run    # validates it and reports how it behaved
+```
+
+`npm run preview` needs no emulator: it stands in for the bar itself. Add
+`--loop` for animated apps and `--png` for a still, and make sure
+`manifest.yaml`'s `preview:` matches the file it wrote.
+
+`npm run check` must come back with no errors before submitting. Read its
+warnings too: they cover the things reviewers otherwise raise by hand.
+
+Then submit per `CONTRIBUTING.md` (fork, add `apps/<slug>/`, open a PR).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,16 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+      - name: Check agent skills sync
+        run: |
+          npm run ai:sync
+          git diff --exit-code
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Uncommitted changes or untracked files detected after running ai:sync"
+            git status --porcelain
+            exit 1
+          fi
+
   check:
     # Advisory: this job reports what busycheck found and never fails the PR.
     # A submission is not blocked on style, it is discussed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      - name: Check agent skills sync
+      - name: Check agent skills are synced
         run: |
           npm run ai:sync
           git diff --exit-code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,6 +238,7 @@ Then go to GitHub and open a pull request. Use this checklist in your PR descrip
 Once you open the PR:
 
 - GitHub Actions will run `npm run build`, which validates your manifest against the content schema
+- CI checks that `.agents/` skills remain synced with `.claude/` (`npm run ai:sync`)
 - The site will build a preview of your app page
 - If validation fails, the PR shows which fields need fixing
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "astro build",
     "serve": "astro preview",
     "astro": "astro",
+    "ai:sync": "python3 scripts/sync-agents.py",
     "preview": "node tools/render/render.mjs",
     "record": "python3 tools/busyrec.py",
     "check": "python3 tools/busycheck.py",

--- a/scripts/sync-agents.py
+++ b/scripts/sync-agents.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Project-level script to sync .claude focused skills to a framework-agnostic .agents directory."""
+
+import filecmp
+import shutil
+import sys
+from pathlib import Path
+
+
+def main():
+    root_dir = Path(__file__).resolve().parent.parent
+    src_dir = root_dir / ".claude" / "skills"
+    dest_dir = root_dir / ".agents" / "skills"
+
+    if not src_dir.exists():
+        print(f"Error: Source directory {src_dir} does not exist.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Syncing from {src_dir.relative_to(root_dir)} to {dest_dir.relative_to(root_dir)}...")
+
+    # Create destination directory if it doesn't exist
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    # Track files to copy and clean up deleted files in destination
+    src_files = {}
+
+    for src_path in src_dir.rglob("*"):
+        if src_path.is_file():
+            rel_path = src_path.relative_to(src_dir)
+            src_files[rel_path] = src_path
+
+    # Delete files in target that are no longer in source
+    for dest_path in dest_dir.rglob("*"):
+        if dest_path.is_file():
+            rel_path = dest_path.relative_to(dest_dir)
+            if rel_path not in src_files:
+                print(f"Removing obsolete target file: {rel_path}")
+                dest_path.unlink()
+
+    # Clean up empty directories in target
+    for dest_path in sorted(dest_dir.rglob("*"), reverse=True):
+        if dest_path.is_dir() and not any(dest_path.iterdir()):
+            dest_path.rmdir()
+
+    # Copy files
+    copied_count = 0
+    for rel_path, src_path in src_files.items():
+        target_path = dest_dir / rel_path
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Only copy if modified or does not exist
+        if not target_path.exists() or not filecmp.cmp(src_path, target_path, shallow=False):
+            shutil.copy2(src_path, target_path)
+            print(f"  Synced: {rel_path}")
+            copied_count += 1
+
+    print(f"Sync complete! {copied_count} file(s) updated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds tooling to mirror `.claude/skills` to a framework-agnostic `.agents/skills` directory so agent tooling and skills are available across various AI tools/frameworks.

### Changes
- Add `scripts/sync-agents.py` to copy skills from `.claude/skills` to `.agents/skills` while cleaning up deleted files.
- Add `npm run ai:sync` npm script in `package.json`.
- Commit the initial `.agents/skills` files to repository.
- Add a CI check step in `.github/workflows/ci.yml` that executes `npm run ai:sync` and verifies there are no uncommitted changes or git diffs.